### PR TITLE
[metadata.extract.calc_enl] raise error when array is empty

### DIFF
--- a/s1ard/metadata/extract.py
+++ b/s1ard/metadata/extract.py
@@ -625,6 +625,9 @@ def calc_enl(tif, block_size=30, return_arr=False, decimals=2):
         arr = ras.array()
     arr[np.isinf(arr)] = np.nan
     
+    if len(arr[~np.isnan(arr)]) == 0:
+        raise RuntimeError('cannot compute ENL for an empty array')
+    
     num_blocks_rows = arr.shape[0] // block_size
     num_blocks_cols = arr.shape[1] // block_size
     if num_blocks_rows == 0 or num_blocks_cols == 0:


### PR DESCRIPTION
This is a preliminary fix until the cause of empty ARD image layers is fixed.  
This is most likely a rare corner case not yet covered in `ard.get_datasets` or the data mask creation process.