### PR TITLE
use COG media type for VRTs

### DIFF
--- a/s1ard/metadata/stac.py
+++ b/s1ard/metadata/stac.py
@@ -410,14 +410,13 @@ def product_json(meta, target, assets, exist_ok=False):
         hash = compute_hash(asset)
         created = None
         header_size = None
-        media_type = pystac.MediaType.XML  # VRT
+        media_type = pystac.MediaType.COG  # COG, VRT
         byte_order = None
         if asset.endswith('.tif'):
             with Raster(asset) as ras:
                 nodata = ras.nodata
             created = datetime.fromtimestamp(os.path.getctime(asset), tz=timezone.utc).isoformat()
             header_size = get_header_size(tif=asset)
-            media_type = pystac.MediaType.COG
             byte_order = ByteOrder.LITTLE_ENDIAN
         
         if 'measurement' in asset:


### PR DESCRIPTION
...so it can be read as xarray by ogc-stac.
This reverts commit https://github.com/SAR-ARD/s1ard/commit/d66e134d4650c6876ef08a6ae2796259e3b5904d (PR https://github.com/SAR-ARD/s1ard/pull/117).