### PR TITLE
valid data mask improvements

### DIFF
--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -548,7 +548,7 @@ def datamask(measurement, dm_ras, dm_vec):
                     if len(mask[mask == 1]) == 0:
                         Path(dm_vec).touch(exist_ok=False)
                         return None
-                    # vectorize the nodata mask
+                    # vectorize the raster data mask
                     with vectorize(target=mask, reference=ras) as vec:
                         # compute a valid data boundary geometry (vector data mask)
                         with boundary(vec, expression="value=1") as bounds:
@@ -566,7 +566,11 @@ def datamask(measurement, dm_ras, dm_vec):
                         Path(dm_vec).touch(exist_ok=False)
                         return None
                     # vectorize the raster data mask
-                    vectorize(target=mask, reference=ras, outname=dm_vec)
+                    with vectorize(target=mask, reference=ras) as vec:
+                        # compute a valid data boundary geometry (vector data mask)
+                        with boundary(vec, expression="value=1") as bounds:
+                            # write the vector data mask
+                            bounds.write(outfile=dm_vec)
         else:
             if os.path.getsize(dm_vec) == 0:
                 return None

--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -537,6 +537,19 @@ def datamask(measurement, dm_ras, dm_vec):
     """
     
     def mask_from_array(arr, dm_vec, dm_ras, ref):
+        """
+        
+        Parameters
+        ----------
+        arr: np.ndarray
+        dm_vec: str
+        dm_ras: str
+        ref: spatialist.raster.Raster
+
+        Returns
+        -------
+        str or None
+        """
         # create a dummy vector mask if the mask only contains 0 values
         if len(arr[arr == 1]) == 0:
             Path(dm_vec).touch(exist_ok=False)
@@ -572,4 +585,6 @@ def datamask(measurement, dm_ras, dm_vec):
         else:
             if os.path.getsize(dm_vec) == 0:
                 out = None
+            else:
+                out = dm_vec
     return out

--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -4,14 +4,17 @@ import logging
 import requests
 import hashlib
 import dateutil.parser
+from pathlib import Path
 from multiformats import multihash
 import binascii
 from lxml import etree
 from textwrap import dedent
 from datetime import datetime, timedelta, timezone
 from osgeo import gdal
+import numpy as np
 import spatialist
-from spatialist.vector import bbox, intersect
+from spatialist.raster import Raster, rasterize
+from spatialist.vector import bbox, intersect, boundary, vectorize
 import pyroSAR
 from pyroSAR.ancillary import Lock
 from pyroSAR import examine, identify_many
@@ -504,3 +507,66 @@ def compute_hash(file_path, algorithm='sha256', chunk_size=8192, multihash_encod
         return mh.hex()
     else:
         return hash_func.hexdigest()
+
+
+def datamask(measurement, dm_ras, dm_vec):
+    """
+    Create data masks for a given image file.
+    The created raster data mask does not contain a simple mask of nodata values.
+    Rather, a boundary vector geometry containing all valid pixels is created and
+    then rasterized. This boundary geometry (single polygon) is saved as `dm_vec`.
+    In this case `dm_vec` is returned.
+    If the input image only contains nodata values, no raster data mask is created,
+    and an empty dummy vector mask is created. In this case the function will return
+    `None`.
+    
+    
+    Parameters
+    ----------
+    measurement: str
+        the binary image file
+    dm_ras: str
+        the name of the raster data mask
+    dm_vec: str
+        the name of the vector data mask
+
+    Returns
+    -------
+    str or None
+        `dm_vec` if the vector data mask contains a geometry or None otherwise
+    """
+    out = dm_vec
+    if not os.path.isfile(dm_vec):
+        if not os.path.isfile(dm_ras):
+            with Raster(measurement) as ras:
+                arr = ras.array()
+                # create a nodata mask
+                mask = ~np.isnan(arr)
+                del arr
+                # create a dummy vector mask if the mask only contains 0 values
+                if len(mask[mask == 1]) == 0:
+                    Path(dm_vec).touch(exist_ok=False)
+                    return None
+                # vectorize the nodata mask
+                with vectorize(target=mask, reference=ras) as vec:
+                    # compute a valid data boundary geometry (vector data mask)
+                    with boundary(vec, expression="value=1") as bounds:
+                        # rasterize the vector data mask
+                        rasterize(vectorobject=bounds, reference=ras,
+                                  outname=dm_ras)
+                        # write the vector data mask
+                        bounds.write(outfile=dm_vec)
+        else:
+            # read the raster data mask
+            with Raster(dm_ras) as ras:
+                mask = ras.array().astype('bool')
+                # create a dummy vector mask if the mask only contains 0 values
+                if len(mask[mask == 1]) == 0:
+                    Path(dm_vec).touch(exist_ok=False)
+                    return None
+                # vectorize the raster data mask
+                vectorize(target=mask, reference=ras, outname=dm_vec)
+    else:
+        if os.path.getsize(dm_vec) == 0:
+            return None
+    return out

--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -579,9 +579,10 @@ def datamask(measurement, dm_ras, dm_vec):
             else:
                 # read the raster data mask
                 with Raster(dm_ras) as ras:
-                    mask = ras.array().astype('bool')
+                    mask = ras.array()
                     out = mask_from_array(arr=mask, dm_vec=dm_vec,
                                           dm_ras=dm_ras, ref=ras)
+                    del mask
         else:
             if os.path.getsize(dm_vec) == 0:
                 out = None

--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -535,7 +535,24 @@ def datamask(measurement, dm_ras, dm_vec):
     str or None
         `dm_vec` if the vector data mask contains a geometry or None otherwise
     """
-    out = dm_vec
+    
+    def mask_from_array(arr, dm_vec, dm_ras, ref):
+        # create a dummy vector mask if the mask only contains 0 values
+        if len(arr[arr == 1]) == 0:
+            Path(dm_vec).touch(exist_ok=False)
+            return None
+        # vectorize the raster data mask
+        with vectorize(target=arr, reference=ref) as vec:
+            # compute a valid data boundary geometry (vector data mask)
+            with boundary(vec, expression="value=1") as bounds:
+                # rasterize the vector data mask
+                if not os.path.isfile(dm_ras):
+                    rasterize(vectorobject=bounds, reference=ref,
+                              outname=dm_ras)
+                # write the vector data mask
+                bounds.write(outfile=dm_vec)
+        return dm_vec
+    
     with LockCollection([dm_vec, dm_ras]):
         if not os.path.isfile(dm_vec):
             if not os.path.isfile(dm_ras):
@@ -544,34 +561,15 @@ def datamask(measurement, dm_ras, dm_vec):
                     # create a nodata mask
                     mask = ~np.isnan(arr)
                     del arr
-                    # create a dummy vector mask if the mask only contains 0 values
-                    if len(mask[mask == 1]) == 0:
-                        Path(dm_vec).touch(exist_ok=False)
-                        return None
-                    # vectorize the raster data mask
-                    with vectorize(target=mask, reference=ras) as vec:
-                        # compute a valid data boundary geometry (vector data mask)
-                        with boundary(vec, expression="value=1") as bounds:
-                            # rasterize the vector data mask
-                            rasterize(vectorobject=bounds, reference=ras,
-                                      outname=dm_ras)
-                            # write the vector data mask
-                            bounds.write(outfile=dm_vec)
+                    out = mask_from_array(arr=mask, dm_vec=dm_vec,
+                                          dm_ras=dm_ras, ref=ras)
             else:
                 # read the raster data mask
                 with Raster(dm_ras) as ras:
                     mask = ras.array().astype('bool')
-                    # create a dummy vector mask if the mask only contains 0 values
-                    if len(mask[mask == 1]) == 0:
-                        Path(dm_vec).touch(exist_ok=False)
-                        return None
-                    # vectorize the raster data mask
-                    with vectorize(target=mask, reference=ras) as vec:
-                        # compute a valid data boundary geometry (vector data mask)
-                        with boundary(vec, expression="value=1") as bounds:
-                            # write the vector data mask
-                            bounds.write(outfile=dm_vec)
+                    out = mask_from_array(arr=mask, dm_vec=dm_vec,
+                                          dm_ras=dm_ras, ref=ras)
         else:
             if os.path.getsize(dm_vec) == 0:
-                return None
+                out = None
     return out

--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -10,17 +10,16 @@ from time import gmtime, strftime
 from copy import deepcopy
 from scipy.interpolate import griddata
 from osgeo import gdal
-from spatialist.vector import Vector, vectorize, boundary, bbox, intersect
-from spatialist.raster import Raster, rasterize, Dtype
+from spatialist.vector import Vector, bbox, intersect
+from spatialist.raster import Raster, Dtype
 from spatialist.auxil import gdalwarp, gdalbuildvrt
 from spatialist.ancillary import finder
 from pyroSAR import identify, identify_many
-from pyroSAR.ancillary import Lock
 import s1ard
 from s1ard import dem, ocn
 from s1ard.metadata import extract, xml, stac
 from s1ard.metadata.mapping import LERC_ERR_THRES
-from s1ard.ancillary import generate_unique_id, vrt_add_overviews
+from s1ard.ancillary import generate_unique_id, vrt_add_overviews, datamask
 from s1ard.metadata.extract import copy_src_meta, get_src_meta, find_in_annotation
 from s1ard.snap import find_datasets
 import logging
@@ -452,7 +451,6 @@ def get_datasets(scenes, datadir, extent, epsg):
     for i, _id in enumerate(ids):
         files = find_datasets(scene=_id.scene, outdir=datadir, epsg=epsg)
         if files is not None:
-            
             base = os.path.splitext(os.path.basename(_id.scene))[0]
             ocn = re.sub('(?:SLC_|GRD[FHM])_1', 'OCN__2', base)[:-5]
             # allow 1 second tolerance
@@ -484,36 +482,10 @@ def get_datasets(scenes, datadir, extent, epsg):
         measurements = [datasets[i][x] for x in datasets[i].keys() if re.search('[gs]-lin', x)]
         dm_ras = os.path.join(os.path.dirname(measurements[0]), 'datamask.tif')
         dm_vec = dm_ras.replace('.tif', '.gpkg')
-        
-        with Lock(dm_ras):
-            if not os.path.isfile(dm_ras):
-                with Raster(measurements[0]) as ras:
-                    arr = ras.array()
-                    mask = ~np.isnan(arr)
-                    del arr
-                    # remove scene if file does not contain valid data
-                    if len(mask[mask == 1]) == 0:
-                        del ids[i], datasets[i]
-                        continue
-                    with vectorize(target=mask, reference=ras) as vec:
-                        with boundary(vec, expression="value=1") as bounds:
-                            if not os.path.isfile(dm_ras):
-                                rasterize(vectorobject=bounds, reference=ras,
-                                          outname=dm_ras)
-                            if not os.path.isfile(dm_vec):
-                                bounds.write(outfile=dm_vec)
-                del mask
-        with Lock(dm_vec):
-            if not os.path.isfile(dm_vec):
-                with Raster(dm_ras) as ras:
-                    mask = ras.array().astype('bool')
-                    # remove scene if file does not contain valid data
-                    if len(mask[mask == 1]) == 0:
-                        del ids[i], datasets[i]
-                        continue
-                    with vectorize(target=mask, reference=ras) as vec:
-                        boundary(vec, expression="value=1", outname=dm_vec)
-                    del mask
+        dm_vec = datamask(measurement=measurements[0], dm_ras=dm_ras, dm_vec=dm_vec)
+        if dm_vec is None:
+            del ids[i], datasets[i]
+            continue
         with Vector(dm_vec) as bounds:
             with bbox(extent, epsg) as tile_geom:
                 inter = intersect(bounds, tile_geom)


### PR DESCRIPTION
in order to determine whether an ARD product can be created from a SLC/GRD Level-1 product, an accurate valid data mask of the processed Level-1 product is needed. The footprint in the metadata is only an estimation.  
This data mask used to be created in `s1ard.ard.get_datasets` as part of gathering processing outputs for a certain Level-1 product.  
Now, this functionality has been moved into a dedicated function `s1ard.ancillary.datamask`. Furthermore, the functionality has been made more robust and easy to read.