### PR TITLE
improved tmp file handling

### DIFF
--- a/s1ard/ancillary.py
+++ b/s1ard/ancillary.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import requests
 import hashlib
+import tempfile
 import dateutil.parser
 from pathlib import Path
 from multiformats import multihash
@@ -589,3 +590,24 @@ def datamask(measurement, dm_ras, dm_vec):
             else:
                 out = dm_vec
     return out
+
+
+def get_tmp_name(suffix):
+    """
+    Get the name of a temporary file with defined suffix.
+    Files are placed in a subdirectory 's1ard' of the regular
+    temporary directory so the latter is not flooded with too
+    many files in case they are not properly deleted.
+    
+    Parameters
+    ----------
+    suffix: str
+        the file suffix/extension, e.g. '.tif'
+
+    Returns
+    -------
+
+    """
+    tmpdir = os.path.join(tempfile.gettempdir(), 's1ard')
+    os.makedirs(tmpdir, exist_ok=True)
+    return tempfile.NamedTemporaryFile(suffix=suffix, dir=tmpdir).name

--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -1081,10 +1081,13 @@ def wind_normalization(src, dst_wm, dst_wn, measurement, gapfill, bounds, epsg, 
         if gapfill:
             cmod_geo = get_tmp_name(suffix='.tif')
             ocn.gapfill(src=cmod_mosaic, dst=cmod_geo, md=2, si=1)
+            os.remove(cmod_mosaic)
         else:
             cmod_geo = cmod_mosaic
+        cmod_geo_tmp = True
     else:
         cmod_geo = src[0]
+        cmod_geo_tmp = False
     
     if not os.path.isfile(dst_wm):
         log.info(f'creating {dst_wm}')
@@ -1098,6 +1101,9 @@ def wind_normalization(src, dst_wm, dst_wn, measurement, gapfill, bounds, epsg, 
                  dstNodata=dst_nodata,
                  multithread=multithread,
                  creationOptions=creation_opt)
+    
+    if cmod_geo_tmp:
+        os.remove(cmod_geo)
     
     if dst_wn is not None and measurement is not None:
         if not os.path.isfile(dst_wn):

--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -2,7 +2,6 @@ import os
 import re
 import time
 import shutil
-import tempfile
 from datetime import datetime, timezone
 import numpy as np
 from lxml import etree
@@ -20,7 +19,7 @@ import s1ard
 from s1ard import dem, ocn
 from s1ard.metadata import extract, xml, stac
 from s1ard.metadata.mapping import LERC_ERR_THRES
-from s1ard.ancillary import generate_unique_id, vrt_add_overviews, datamask
+from s1ard.ancillary import generate_unique_id, vrt_add_overviews, datamask, get_tmp_name
 from s1ard.metadata.extract import copy_src_meta, get_src_meta, find_in_annotation
 from s1ard.snap import find_datasets
 import logging
@@ -211,7 +210,7 @@ def format(config, product_type, scenes, datadir, outdir, tile, extent, epsg, wb
                 ras = Raster(images, list_separate=False)
                 source = ras.filename
             else:
-                source = tempfile.NamedTemporaryFile(suffix='.vrt').name
+                source = get_tmp_name(suffix='.vrt')
                 gdalbuildvrt(src=images[0], dst=source)
             
             # modify temporary VRT to make sure overview levels and resampling are properly applied
@@ -1077,10 +1076,10 @@ def wind_normalization(src, dst_wm, dst_wn, measurement, gapfill, bounds, epsg, 
     
     """
     if len(src) > 1:
-        cmod_mosaic = tempfile.NamedTemporaryFile(suffix='.tif').name
+        cmod_mosaic = get_tmp_name(suffix='.tif')
         gdalwarp(src=src, dst=cmod_mosaic)
         if gapfill:
-            cmod_geo = tempfile.NamedTemporaryFile(suffix='.tif').name
+            cmod_geo = get_tmp_name(suffix='.tif')
             ocn.gapfill(src=cmod_mosaic, dst=cmod_geo, md=2, si=1)
         else:
             cmod_geo = cmod_mosaic

--- a/s1ard/dem.py
+++ b/s1ard/dem.py
@@ -355,3 +355,4 @@ def to_mgrs(tile, dst, dem_type, overviews, tr, format='COG',
                geoid_convert=geoid_convert, geoid=geoid, pbar=pbar,
                outputBounds=bounds, threads=threads, format=format,
                creationOptions=create_options)
+    os.remove(vrt)

--- a/s1ard/dem.py
+++ b/s1ard/dem.py
@@ -1,11 +1,10 @@
 import os
 import re
-import tempfile
 import itertools
 from getpass import getpass
 from pyroSAR.auxdata import dem_autoload, dem_create
 import s1ard.tile_extraction as tile_ex
-from s1ard.ancillary import generate_unique_id, get_max_ext, vrt_add_overviews
+from s1ard.ancillary import generate_unique_id, get_max_ext, vrt_add_overviews, get_tmp_name
 from spatialist import Raster, bbox
 import logging
 
@@ -347,7 +346,7 @@ def to_mgrs(tile, dst, dem_type, overviews, tr, format='COG',
     ext['ymin'] -= buffer
     ext['xmax'] += buffer
     ext['ymax'] += buffer
-    vrt = tempfile.NamedTemporaryFile(suffix='.vrt').name
+    vrt = get_tmp_name(suffix='.vrt')
     with bbox(coordinates=ext, crs=epsg) as vec:
         vec.reproject(4326)
         dem_autoload(geometries=[vec], demType=dem_type, vrt=vrt)

--- a/s1ard/metadata/extract.py
+++ b/s1ard/metadata/extract.py
@@ -2,7 +2,6 @@ import os
 import re
 import shutil
 import zipfile
-import tempfile
 import math
 from statistics import mean
 import json
@@ -20,6 +19,7 @@ import s1ard
 from s1ard.metadata.mapping import (ARD_PATTERN, LERC_ERR_THRES, RES_MAP_SLC, RES_MAP_GRD, ENL_MAP_GRD, OSV_MAP,
                                     DEM_MAP, SLC_ACC_MAP)
 from s1ard import snap
+from s1ard.ancillary import get_tmp_name
 
 gdal.UseExceptions()
 
@@ -820,8 +820,8 @@ def calc_wm_ref_stats(wm_ref_files, epsg, bounds, resolution=915):
     files_speed = [f for f in wm_ref_files if f.endswith('Speed.tif')]
     files_direction = [f for f in wm_ref_files if f.endswith('Direction.tif')]
     
-    ref_speed = tempfile.NamedTemporaryFile(suffix='.tif', delete=False).name
-    ref_direction = tempfile.NamedTemporaryFile(suffix='.tif', delete=False).name
+    ref_speed = get_tmp_name(suffix='.tif')
+    ref_direction = get_tmp_name(suffix='.tif')
     
     out = []
     for src, dst in zip([files_speed, files_direction], [ref_speed, ref_direction]):


### PR DESCRIPTION
This stores all temporary files created by `s1ard` in a directory `$TMPDIR/s1ard` and deletes them once they are no longer needed. Before, `$TMPDIR` gradually filled up with files (mostly VRTs) eventually preventing operations like `rm -rf $TMPDIR/*` because of too many items.