### PR TITLE
snap pre modifications

### DIFF
--- a/s1ard/snap.py
+++ b/s1ard/snap.py
@@ -168,7 +168,7 @@ def pre(src, dst, workflow, allow_res_osv=True, osv_continue_on_fail=False,
             gpt_args=gpt_args, removeS1BorderNoiseMethod='ESA')
         if scene.product == 'GRD':
             try:
-                nrt_slice_num(dim=scene.scene)
+                nrt_slice_num(dim=dst)
             except RuntimeError:
                 raise RuntimeError('cannot obtain slice number')
 


### PR DESCRIPTION
This makes some modifications to the processing workflow so that the products generated during preprocessing are not modified in succeeding steps:
- [snap.nrt_slice_num()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.snap.nrt_slice_num) is now called in [snap.pre()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.snap.pre) instead of [snap.grd_buffer()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.snap.grd_buffer)
- [ancillary.datamask()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.ancillary.datamask) is now called in [snap.process()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.snap.process). In [ard.format()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.ard.format) it is still called but only to retrieve the file name of the previously created mask and not to actually create it

This way, the products are finalized once [snap.pre()](https://s1ard.readthedocs.io/en/latest/api.html#s1ard.snap.pre) terminates and no other process needs to write-lock them for modification, which avoids conflicts in parallel processes.