### PR TITLE
scene search optimizations

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -140,7 +140,7 @@ Tile Extraction
         description2dict
         multipolygon2polygon
         tile_from_aoi
-        wkt_to_geom
+        wkt2vector_regrid
 
 Ancillary Functions
 -------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -157,6 +157,7 @@ Ancillary Functions
         buffer_time
         check_scene_consistency
         check_spacing
+        combine_polygons
         compute_hash
         datamask
         date_to_utc
@@ -186,7 +187,6 @@ Scene Search
         check_acquisition_completeness
         collect_neighbors
         scene_select
-        combine_polygons
 
 Metadata
 --------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - pystac>=1.8.0,<1.11.0
   - pystac-client>=0.7.0
   - scipy
-  - pyroSAR>=0.27.0
+  - pyroSAR>=0.28.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pystac>=1.8.0,<1.11.0
   - pystac-client>=0.7.0
   - scipy
-  - pyroSAR>=0.27.0
+  - pyroSAR>=0.28.0
   - spatialist>=0.12.0
   - s1etad>=0.5.3
   - s1etad_tools>=0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ multiformats>=0.3.1
 numpy<2.0
 packaging
 pyproj
-pyroSAR>=0.27.0
+pyroSAR>=0.28.0
 pystac>=1.8.0,<1.11.0
 pystac-client>=0.7.0
 python-dateutil

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -253,22 +253,19 @@ class STACArchive(object):
                 else:
                     raise TypeError('argument vectorobject must be of type spatialist.vector.Vector')
             else:
-                args2 = []
                 if isinstance(val, (str, int)):
                     val = [val]
+                val_format = []
                 for v in val:
                     if key == 'sensor':
-                        value = lookup_platform[v]
-                    elif key == 'frameNumber' and isinstance(v, int):
-                        value = '{:06X}'.format(v)  # convert to hexadecimal
-                    else:
-                        value = v
-                    a = {'op': '=', 'args': [{'property': lookup[key]}, value]}
-                    args2.append(a)
-                if len(args2) == 1:
-                    arg = args2[0]
+                        v = lookup_platform[v]
+                    if key == 'frameNumber' and isinstance(v, int):
+                        v = '{:06X}'.format(v)  # convert to hexadecimal
+                    val_format.append(v)
+                if len(val_format) == 1:
+                    arg = {'op': '=', 'args': [{'property': lookup[key]}, val_format[0]]}
                 else:
-                    arg = {'op': 'or', 'args': args2}
+                    arg = {'op': 'in', 'args': [{'property': lookup[key]}, val_format]}
                 flt['args'].append(arg)
         if len(flt['args']) == 0:
             flt = None

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -345,8 +345,8 @@ class STACParquetArchive(object):
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
         maxdate: str or datetime.datetime or None
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber: int or list[int] or None
-            the data take ID in decimal representation.
+        frameNumber: int or str or list[int or str] or None
+            the data take ID in decimal (int) or hexadecimal (str) representation.
             Requires custom STAC key `s1:datatake`.
         vectorobject: spatialist.vector.Vector or None
             a geometry with which the scenes need to overlap
@@ -422,8 +422,8 @@ class STACParquetArchive(object):
                 for v in val:
                     if key == 'sensor':
                         v = lookup_platform[v]
-                    if key == 'frameNumber' and isinstance(v, str):
-                        v = int(v, 16)  # convert to decimal
+                    elif key == 'frameNumber' and isinstance(v, int):
+                        value = '{:06X}'.format(v)  # convert to hexadecimal
                     subterms.append(f'"{lookup[key]}" = \'{v}\'')
                 if len(subterms) > 1:
                     terms.append('(' + ' OR '.join(subterms) + ')')

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -10,9 +10,8 @@ from pystac_client.stac_api_io import StacApiIO
 from spatialist.vector import Vector, crsConvert
 import asf_search as asf
 from pyroSAR import identify_many, ID
-from s1ard.ancillary import date_to_utc, buffer_time
+from s1ard.ancillary import date_to_utc, buffer_time, combine_polygons
 from s1ard.tile_extraction import aoi_from_tile, tile_from_aoi
-from osgeo import ogr, osr
 import logging
 
 log = logging.getLogger('s1ard')
@@ -907,74 +906,3 @@ def check_acquisition_completeness(archive, scenes):
     if len(messages) != 0:
         text = '\n - '.join(messages)
         raise RuntimeError(f'missing the following scenes:\n - {text}')
-
-
-def combine_polygons(vector, crs=4326, multipolygon=False, layer_name='combined'):
-    """
-    Combine polygon vector objects into one.
-    The output is a single vector object with the polygons either stored in
-    separate features or combined into a single multipolygon geometry.
-
-    Parameters
-    ----------
-    vector: spatialist.vector.Vector or list[spatialist.vector.Vector]
-        the input vector object(s). Providing only one object only makes sense when `multipolygon=True`.
-    crs: int or str
-        the target CRS. Default: EPSG:4326
-    multipolygon: bool
-        combine all polygons into one multipolygon?
-        Default False: write each polygon into a separate feature.
-    layer_name: str
-        the layer name of the output vector object.
-
-    Returns
-    -------
-    spatialist.vector.Vector
-    """
-    if not isinstance(vector, list):
-        vector = [vector]
-    ##############################################################################
-    # check geometry types
-    geometry_names = []
-    for item in vector:
-        for feature in item.layer:
-            geom = feature.GetGeometryRef()
-            geometry_names.append(geom.GetGeometryName())
-        item.layer.ResetReading()
-    geom = None
-    geometry_names = list(set(geometry_names))
-    if not all(x == 'POLYGON' for x in geometry_names):
-        raise RuntimeError('All geometries must be of type POLYGON')
-    ##############################################################################
-    vec = Vector(driver='Memory')
-    srs_out = crsConvert(crs, 'osr')
-    if multipolygon:
-        geom_type = ogr.wkbMultiPolygon
-        geom_out = ogr.Geometry(geom_type)
-    else:
-        geom_type = ogr.wkbPolygon
-        geom_out = []
-    vec.addlayer(name=layer_name, srs=srs_out, geomType=geom_type)
-    for item in vector:
-        if item.srs.IsSame(srs_out):
-            coord_trans = None
-        else:
-            coord_trans = osr.CoordinateTransformation(item.srs, srs_out)
-        for feature in item.layer:
-            geom = feature.GetGeometryRef()
-            if coord_trans is not None:
-                geom.Transform(coord_trans)
-            if multipolygon:
-                geom_out.AddGeometry(geom.Clone())
-            else:
-                geom_out.append(geom.Clone())
-        item.layer.ResetReading()
-    geom = None
-    if multipolygon:
-        geom_out = geom_out.UnionCascaded()
-        vec.addfeature(geom_out)
-    else:
-        for geom in geom_out:
-            vec.addfeature(geom)
-    geom_out = None
-    return vec

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -181,8 +181,8 @@ class STACArchive(object):
             the minimum acquisition date; timezone-unaware dates are interpreted as UTC.
         maxdate: str or datetime.datetime or None
             the maximum acquisition date; timezone-unaware dates are interpreted as UTC.
-        frameNumber: int or list[int] or None
-            the data take ID in decimal representation.
+        frameNumber: int or str or list[int or str] or None
+            the data take ID in decimal (int) or hexadecimal (str) representation.
             Requires custom STAC key `s1:datatake`.
         vectorobject: spatialist.vector.Vector or None
             a geometry with which the scenes need to overlap. The object may only contain one feature.
@@ -259,7 +259,7 @@ class STACArchive(object):
                 for v in val:
                     if key == 'sensor':
                         value = lookup_platform[v]
-                    elif key == 'frameNumber':
+                    elif key == 'frameNumber' and isinstance(v, int):
                         value = '{:06X}'.format(v)  # convert to hexadecimal
                     else:
                         value = v

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -913,7 +913,8 @@ def combine_polygons(vector, crs=4326, multipolygon=False, layer_name='combined'
 
     Parameters
     ----------
-    vector: list[spatialist.vector.Vector]
+    vector: spatialist.vector.Vector or list[spatialist.vector.Vector]
+        the input vector object(s). Providing only one object only makes sense when `multipolygon=True`.
     crs: int or str
         the target CRS. Default: EPSG:4326
     multipolygon: bool
@@ -927,7 +928,9 @@ def combine_polygons(vector, crs=4326, multipolygon=False, layer_name='combined'
     spatialist.vector.Vector
     """
     if not isinstance(vector, list):
-        raise TypeError("'vectorobject' must be a list")
+        vector = [vector]
+    ##############################################################################
+    # check geometry types
     geometry_names = []
     for item in vector:
         for feature in item.layer:
@@ -938,7 +941,7 @@ def combine_polygons(vector, crs=4326, multipolygon=False, layer_name='combined'
     geometry_names = list(set(geometry_names))
     if not all(x == 'POLYGON' for x in geometry_names):
         raise RuntimeError('All geometries must be of type POLYGON')
-    
+    ##############################################################################
     vec = Vector(driver='Memory')
     srs_out = crsConvert(crs, 'osr')
     if multipolygon:

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -715,8 +715,10 @@ def scene_select(archive, aoi_tiles=None, aoi_geometry=None, **kwargs):
     
     # extend the time range to fully cover all tiles
     # (one additional scene needed before and after each data take group)
-    args['mindate'] -= timedelta(minutes=1)
-    args['maxdate'] += timedelta(minutes=1)
+    if 'mindate' in args.keys():
+        args['mindate'] -= timedelta(minutes=1)
+    if 'maxdate' in args.keys():
+        args['maxdate'] += timedelta(minutes=1)
     
     if isinstance(archive, ASFArchive):
         args['return_value'] = 'url'

--- a/s1ard/search.py
+++ b/s1ard/search.py
@@ -415,17 +415,18 @@ class STACParquetArchive(object):
             else:
                 if isinstance(val, (str, int)):
                     val = [val]
-                subterms = []
+                val_format = []
                 for v in val:
                     if key == 'sensor':
                         v = lookup_platform[v]
-                    elif key == 'frameNumber' and isinstance(v, int):
-                        value = '{:06X}'.format(v)  # convert to hexadecimal
-                    subterms.append(f'"{lookup[key]}" = \'{v}\'')
-                if len(subterms) > 1:
-                    terms.append('(' + ' OR '.join(subterms) + ')')
+                    if key == 'frameNumber' and isinstance(v, int):
+                        v = '{:06X}'.format(v)  # convert to hexadecimal
+                    val_format.append(v)
+                if len(val_format) == 1:
+                    subterm = f'"{lookup[key]}" = \'{val_format[0]}\''
                 else:
-                    terms.append(subterms[0])
+                    subterm = f'"{lookup[key]}" IN {tuple(val_format)}'
+                terms.append(subterm)
         sql_where = ' AND '.join(terms)
         sql_query = f"""
         SELECT

--- a/s1ard/tile_extraction.py
+++ b/s1ard/tile_extraction.py
@@ -156,25 +156,28 @@ def description2dict(description):
 
 def aoi_from_scene(scene, multi=True, percent=1):
     """
-    Get processing AOIs for a SAR scene. The MGRS grid requires a SAR scene to be geocoded to multiple UTM zones
-    depending on the overlapping MGRS tiles and their projection. This function returns the following for each
-    UTM zone group:
+    Get processing AOIs for a SAR scene. The MGRS grid requires a SAR
+    scene to be geocoded to multiple UTM zones depending on the overlapping
+    MGRS tiles and their projection. This function returns the following
+    for each UTM zone group:
     
     - the extent in WGS84 coordinates (key `extent`)
     - the EPSG code of the UTM zone (key `epsg`)
     - the Easting coordinate for pixel alignment (key `align_x`)
     - the Northing coordinate for pixel alignment (key `align_y`)
     
-    A minimum overlap of the AOIs with the SAR scene is ensured by buffering the AOIs if necessary.
-    The minimum overlap can be controlled with parameter `percent`.
+    A minimum overlap of the AOIs with the SAR scene is ensured by buffering
+    the AOIs if necessary. The minimum overlap can be controlled with
+    parameter `percent`.
     
     Parameters
     ----------
     scene: pyroSAR.drivers.ID
         the SAR scene object
     multi: bool
-        split into multiple AOIs per overlapping UTM zone or just one AOI covering the whole scene.
-        In the latter case the best matching UTM zone is auto-detected
+        split into multiple AOIs per overlapping UTM zone or just one AOI
+        covering the whole scene. In the latter case the best matching UTM
+        zone is auto-detected
         (using function :func:`spatialist.auxil.utm_autodetect`).
     percent: int or float
         the minimum overlap in percent of each AOI with the SAR scene.
@@ -183,9 +186,9 @@ def aoi_from_scene(scene, multi=True, percent=1):
     Returns
     -------
     list[dict]
-        a list of dictionaries with keys `extent`, `epsg`, `align_x`, `align_y`
+        a list of dictionaries with keys `extent`, `epsg`, `align_x`,
+        `align_y`
     """
-    kml = get_kml()
     out = []
     if multi:
         # extract all overlapping tiles

--- a/s1ard/tile_extraction.py
+++ b/s1ard/tile_extraction.py
@@ -67,9 +67,9 @@ def tile_from_aoi(vector, epsg=None, strict=True, return_geometries=False, tilen
                         continue
                 if return_geometries:
                     wkt = multipolygon2polygon(attrib['UTM_WKT'])
-                    geom = wkt_to_geom(wkt=wkt,
-                                       epsg_in=attrib['EPSG'],
-                                       epsg_out=epsg_target)
+                    geom = wkt2vector_regrid(wkt=wkt,
+                                             epsg_in=attrib['EPSG'],
+                                             epsg_out=epsg_target)
                     geom.mgrs = tilename
                     tiles.append(geom)
                 else:
@@ -121,9 +121,9 @@ def aoi_from_tile(tile):
             attrib = description2dict(feat.GetField('Description'))
             wkt = multipolygon2polygon(attrib['UTM_WKT'])
             epsg_target = epsg_codes[i]
-            geom = wkt_to_geom(wkt=wkt,
-                               epsg_in=attrib['EPSG'],
-                               epsg_out=epsg_target)
+            geom = wkt2vector_regrid(wkt=wkt,
+                                     epsg_in=attrib['EPSG'],
+                                     epsg_out=epsg_target)
             out.append(geom)
         vec.vector.ReleaseResultSet(result_layer)
     if len(out) == 1:
@@ -270,9 +270,10 @@ def multipolygon2polygon(wkt):
     return wkt
 
 
-def wkt_to_geom(wkt, epsg_in, epsg_out=None):
+def wkt2vector_regrid(wkt, epsg_in, epsg_out=None):
     """
-    Convert a WKT geometry to a :class:`spatialist.vector.Vector` object.
+    Convert a WKT geometry to a :class:`spatialist.vector.Vector` object and
+    optionally reproject and regrid it.
 
     Parameters
     ----------
@@ -287,6 +288,10 @@ def wkt_to_geom(wkt, epsg_in, epsg_out=None):
     -------
     spatialist.vector.Vector
         the geometry object
+    
+    See Also
+    --------
+    spatialist.vector.wkt2vector
     """
     if epsg_out is None:
         return wkt2vector(wkt, epsg_in)

--- a/s1ard/tile_extraction.py
+++ b/s1ard/tile_extraction.py
@@ -3,7 +3,7 @@ import itertools
 from lxml import html
 from spatialist.vector import Vector, wkt2vector, bbox
 from spatialist.auxil import utm_autodetect
-from s1ard.ancillary import get_max_ext, buffer_min_overlap, get_kml
+from s1ard.ancillary import get_max_ext, buffer_min_overlap, get_kml, combine_polygons
 from osgeo import ogr
 
 
@@ -36,53 +36,48 @@ def tile_from_aoi(vector, epsg=None, strict=True, return_geometries=False, tilen
     """
     if isinstance(epsg, int):
         epsg = [epsg]
-    if not isinstance(vector, list):
-        vectors = [vector]
-    else:
-        vectors = vector
-    for vector in vectors:
-        if vector.getProjection('epsg') != 4326:
-            raise RuntimeError('the CRS of the input vector object(s) must be EPSG:4326')
     sortkey = None
     if return_geometries:
         sortkey = lambda x: x.mgrs
     kml = get_kml()
-    with Vector(kml, driver='KML') as vec:
-        tilenames_src = []
+    with Vector(kml, driver='KML') as vec_kml:
         tiles = []
-        for vector in vectors:
-            vector.layer.ResetReading()
-            for item in vector.layer:
-                geom = item.GetGeometryRef()
-                vec.layer.SetSpatialFilter(geom)
-                for tile in vec.layer:
-                    tilename = tile.GetField('Name')
-                    c1 = tilename not in tilenames_src
-                    c2 = tilenames is None or tilename in tilenames
-                    if c1 and c2:
-                        tilenames_src.append(tilename)
-                        attrib = description2dict(tile.GetField('Description'))
-                        epsg_target = None
-                        if epsg is not None and attrib['EPSG'] not in epsg:
-                            if len(epsg) == 1 and not strict:
-                                epsg_target = int(epsg[0])
-                                tilename += '_{}'.format(epsg_target)
-                            else:
-                                continue
-                        if return_geometries:
-                            wkt = multipolygon2polygon(attrib['UTM_WKT'])
-                            geom = wkt_to_geom(wkt=wkt,
-                                               epsg_in=attrib['EPSG'],
-                                               epsg_out=epsg_target)
-                            geom.mgrs = tilename
-                            tiles.append(geom)
-                        else:
-                            tiles.append(tilename)
-            vector.layer.ResetReading()
-        tile = None
-        geom = None
-        item = None
-        return sorted(tiles, key=sortkey)
+        with combine_polygons(vector, multipolygon=True) as vec_aoi:
+            feature = vec_aoi.getFeatureByIndex(0)
+            geom = feature.GetGeometryRef()
+            vec_kml.layer.SetSpatialFilter(geom)
+            feature = geom = None
+            if tilenames is not None:
+                values = ", ".join([f"'{x}'" for x in tilenames])
+                sql_where = f"Name IN ({values})"
+                layer_name = vec_kml.layer.GetName()
+                query = f"SELECT * FROM {layer_name} WHERE {sql_where}"
+                layer = vec_kml.vector.ExecuteSQL(query)
+            else:
+                layer = vec_kml.layer
+            for tile in layer:
+                tilename = tile.GetField('Name')
+                attrib = description2dict(tile.GetField('Description'))
+                epsg_target = None
+                if epsg is not None and attrib['EPSG'] not in epsg:
+                    if len(epsg) == 1 and not strict:
+                        epsg_target = int(epsg[0])
+                        tilename += '_{}'.format(epsg_target)
+                    else:
+                        continue
+                if return_geometries:
+                    wkt = multipolygon2polygon(attrib['UTM_WKT'])
+                    geom = wkt_to_geom(wkt=wkt,
+                                       epsg_in=attrib['EPSG'],
+                                       epsg_out=epsg_target)
+                    geom.mgrs = tilename
+                    tiles.append(geom)
+                else:
+                    tiles.append(tilename)
+            tile = None
+            geom = None
+            layer = None
+    return sorted(tiles, key=sortkey)
 
 
 def aoi_from_tile(tile):


### PR DESCRIPTION
- `ancillary.combine_polygons`
  - moved from `search.combine_polygons`
  - now also takes a single vector object as input so that its poylgons can be combined into a single multipolygon; In case of a large number of polygons, this may significantly speed up spatial queries (from the MGRS KML file or scene database)
- `search.scene_select`:
  - fixed bug in handling of `mindate` and `maxdate` parameters, which prevented search without date constraints
  - new argument `cores` for parallelized scene metadata extraction
- `search.STACArchive`/`search.STACParquetArchive`
  - allow hex strings for `frameNumber` argument
  - simplify filter statement with 'in' operator
- `search.STACParquetArchive`: assume hex strings as value for `s1:datatake` metadata parameter
- `tile_extraction.tile_from_aoi`: accelerate query with `ancillary.combine_polygons` and SQL query
- `tile_extraction.wkt2vector_regrid`: renamed from `tile_extraction.wkt_to_geom`