### PR TITLE
[snap.process] fixed bug in not reassigning out_pre when buffering has already been performed

### DIFF
--- a/s1ard/snap.py
+++ b/s1ard/snap.py
@@ -721,6 +721,7 @@ def process(scene, outdir, measurement, spacing, dem,
                                  'could not be determined')
                         pass
             else:
+                out_pre = out_buffer
                 log.info('GRD scene has already been buffered')
     ############################################################################
     # range look direction angle


### PR DESCRIPTION
... leading to the initial preprocessed product being used for subsequent steps instead of the buffered one.