### PR TITLE
require at least one pixel overlap with the MGRS tile

### DIFF
--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -497,6 +497,12 @@ def get_datasets(scenes, datadir, extent, epsg):
             with Vector(dm_vec) as bounds:
                 with bbox(extent, epsg) as tile_geom:
                     inter = intersect(bounds, tile_geom)
+                    if inter is not None:
+                        with Raster(dm_ras) as ras:
+                            inter_min = ras.res[0] * ras.res[1]
+                        if inter.getArea() < inter_min:
+                            inter.close()
+                            inter = None
                     if inter is None:
                         log.debug('no overlap, removing scene')
                         del ids[i]


### PR DESCRIPTION
...instead of just checking whether the processor output overlaps with an MGRS tile. This overlap can be so small that no valid pixel is contained in the tiled image products rendering the product useless.  
With this fix, the intersection area must be at least the size of one pixel. Whether single-pixel products are meaningful is still debatable however. See https://github.com/SAR-ARD/s1ard/issues/182.