### PR TITLE
product acquisition time improvements

### DIFF
--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -785,7 +785,9 @@ def calc_product_start_stop(src_ids, extent, epsg):
         
         t_flat = np.asarray(
             [datetime.fromisoformat(item)
-             .timestamp() for item in t_flat]
+             .replace(tzinfo=timezone.utc)
+             .timestamp()
+             for item in t_flat]
         )
         
         y_flat = np.asarray([float(item) for item in y_flat])
@@ -797,7 +799,8 @@ def calc_product_start_stop(src_ids, extent, epsg):
     
     if len(uids) == 2:
         starts = [src_dict[uid]['sid'].start for uid in uids]
-        starts = [datetime.strptime(x, '%Y%m%dT%H%M%S') for x in starts]
+        starts = [datetime.strptime(x, '%Y%m%dT%H%M%S')
+                  .replace(tzinfo=timezone.utc) for x in starts]
         az_time = [src_dict[key]['az_time'] for key in src_dict.keys()]
         gridpts = [src_dict[key]['gridpts'] for key in src_dict.keys()]
         if starts[0] > starts[1]:
@@ -827,7 +830,7 @@ def calc_product_start_stop(src_ids, extent, epsg):
                 res_t.append(max(az_time))
         else:
             res_t.append(float(r))
-    res_t = [datetime.fromtimestamp(x) for x in res_t]
+    res_t = [datetime.fromtimestamp(x, tz=timezone.utc) for x in res_t]
     
     start = datetime.strftime(res_t[0], '%Y%m%dT%H%M%S')
     stop = datetime.strftime(res_t[1], '%Y%m%dT%H%M%S')

--- a/s1ard/ard.py
+++ b/s1ard/ard.py
@@ -795,13 +795,9 @@ def calc_product_start_stop(src_ids, extent, epsg):
         src_dict[uid]['az_time'] = t_flat
         src_dict[uid]['gridpts'] = g
     
-    starts = [src_dict[uid]['sid'].start for uid in uids]
-    starts = [datetime.strptime(x, '%Y%m%dT%H%M%S') for x in starts]
-    
-    stops = [src_dict[uid]['sid'].stop for uid in uids]
-    stops = [datetime.strptime(x, '%Y%m%dT%H%M%S') for x in stops]
-    
     if len(uids) == 2:
+        starts = [src_dict[uid]['sid'].start for uid in uids]
+        starts = [datetime.strptime(x, '%Y%m%dT%H%M%S') for x in starts]
         az_time = [src_dict[key]['az_time'] for key in src_dict.keys()]
         gridpts = [src_dict[key]['gridpts'] for key in src_dict.keys()]
         if starts[0] > starts[1]:
@@ -826,11 +822,12 @@ def calc_product_start_stop(src_ids, extent, epsg):
     for i, r in enumerate(res):
         if np.isnan(r):
             if i == 0:
-                res_t.append(min(starts))
+                res_t.append(min(az_time))
             else:
-                res_t.append(max(stops))
+                res_t.append(max(az_time))
         else:
-            res_t.append(datetime.fromtimestamp(float(r)))
+            res_t.append(float(r))
+    res_t = [datetime.fromtimestamp(x) for x in res_t]
     
     start = datetime.strftime(res_t[0], '%Y%m%dT%H%M%S')
     stop = datetime.strftime(res_t[1], '%Y%m%dT%H%M%S')


### PR DESCRIPTION
The function `calc_product_start_stop` calculates product acquisition times by interpolating the source product azimuth time grid to the coordinates of the MGRS tile.

changes made:
- fixed bug in UTC time stamps being converted to local time zone
- use higher precision time stamps in product metadata
- code formatting

remaining issue: If the MGRS coordinate is outside of the source product footprints, the function uses the source product's start/stop time. This is very inaccurate:
![image](https://github.com/user-attachments/assets/394d2537-6654-45e4-bcb7-75a3b27aa359)
The bottom left coordinate of the MGRS tile gets the same value as the southernmost coordinate of the source scenes whereas it should get a value of a coordinate with the same latitude (close to the bottom right coordinate of the MGRS scene).

The values should not be interpolated for the corner coordinates of the MGRS tile. Rather the intersection between the MGRS tile and the source scene footprints should be used.