### PR TITLE
config: new function init, write bug fix

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -14,6 +14,7 @@ Configuration
 
         gdal_conf
         get_config
+        init
         snap_conf
         write
 

--- a/s1ard/cli.py
+++ b/s1ard/cli.py
@@ -1,5 +1,4 @@
 import click
-import importlib.resources
 
 
 @click.group(name='s1rb',
@@ -70,14 +69,11 @@ def init(ctx, config_file, overwrite=False, config_source=None):
     - licence:           None
     - processing_center: None
     """
-    from s1ard.config import get_config, write
-    extra = {ctx.args[i][2:]: ctx.args[i + 1] for i in range(0, len(ctx.args), 2)}
-    if config_source is None:
-        with importlib.resources.path(package='s1ard.resources',
-                                      resource='config.ini') as path:
-            config_source = str(path)
-    config = get_config(config_file=config_source, **extra)
-    write(config=config, target=config_file, overwrite=overwrite)
+    from s1ard.config import init as init_config
+    extra = {ctx.args[i][2:]: ctx.args[i + 1]
+             for i in range(0, len(ctx.args), 2)}
+    init_config(target=config_file, source=config_source,
+                overwrite=overwrite, **extra)
 
 
 @cli.command(name='process',

--- a/s1ard/config.py
+++ b/s1ard/config.py
@@ -472,7 +472,9 @@ def write(config, target, overwrite=False, **kwargs):
         if v is not None and work_dir in v:
             config['processing'][k] = v.replace(work_dir, '').strip('/\\')
     k = 'snap_gpt_args'
-    v = ' '.join([str(x) for x in config['processing'][k]])
+    v = config['processing'][k]
+    if v is not None:
+        v = ' '.join([str(x) for x in config['processing'][k]])
     config['processing'][k] = v
     config = to_string(config)
     parser = configparser.ConfigParser()

--- a/s1ard/config.py
+++ b/s1ard/config.py
@@ -250,6 +250,43 @@ def get_config(config_file=None, **kwargs):
     return out_dict
 
 
+def init(target, source=None, overwrite=False, **kwargs):
+    """
+    Initialize a configuration file.
+
+    Parameters
+    ----------
+    target : str
+        Path to the target configuration file.
+    source : str, optional
+        Path to the source file to read the configuration from. If not provided,
+        a default configuration file within the package will be used.
+    overwrite : bool, default=False
+        Overwrite an existing file?
+    kwargs : Any
+        Additional keyword arguments for overwriting the configuration in `source`.
+    
+    Returns
+    -------
+    
+    Examples
+    --------
+    Create a file in the current working directory.
+    `work_dir` and a scene search option (in this case SQLite via `db_file`)
+    must be defined, other configuration is read from the default configuration file.
+    
+    >>> from s1ard.config import init
+    >>> init(target='config.ini', work_dir='.', db_file='scenes.db')
+
+    """
+    if source is None:
+        with importlib.resources.path(package='s1ard.resources',
+                                      resource='config.ini') as path:
+            source = str(path)
+    config = get_config(config_file=source, **kwargs)
+    write(config=config, target=target, overwrite=overwrite)
+
+
 def _parse_annotation(s):
     """Custom converter for configparser:
     https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import pytest
+from s1ard.config import init
+
+
+def test_init(tmpdir):
+    target = str(tmpdir / 'config.ini')
+    # work_dir undefined
+    with pytest.raises(AssertionError):
+        init(target=target)
+    # no search option defined
+    with pytest.raises(RuntimeError):
+        init(target=target, work_dir=str(tmpdir))
+    init(target=target, work_dir=str(tmpdir), db_file='scenes.db')
+    # file already exists
+    with pytest.raises(RuntimeError):
+        init(target=target, work_dir=str(tmpdir), db_file='scenes.db')


### PR DESCRIPTION
This introduces a new function `s1ard.config.init` and fixes a bug in `s1ard.config.write` where the case `snap_gpt_args=None` was not considered.