### PR TITLE
[metadata.extract] OSV info gathering improvements

### DIFF
--- a/s1ard/metadata/extract.py
+++ b/s1ard/metadata/extract.py
@@ -27,9 +27,10 @@ gdal.UseExceptions()
 def meta_dict(config, target, src_ids, sar_dir, proc_time, start, stop,
               compression, product_type, wm_ref_files=None):
     """
-    Creates a dictionary containing metadata for a product scene, as well as its source scenes. The dictionary can then
-    be utilized by :func:`~s1ard.metadata.xml.parse` and :func:`~s1ard.metadata.stac.parse` to generate OGC XML and
-    STAC JSON metadata files, respectively.
+    Creates a dictionary containing metadata for a product scene, as well
+    as its source scenes. The dictionary can then be used
+    by :func:`~s1ard.metadata.xml.parse` and :func:`~s1ard.metadata.stac.parse`
+    to generate OGC XML and STAC JSON metadata files, respectively.
     
     Parameters
     ----------


### PR DESCRIPTION
This is a dummy PR to highlight the changes made in https://github.com/SAR-ARD/s1ard/commit/3fa045cd83c5388acf5ecf81eeb1c41abde10959 (which was accidentally directly pushed to the main branch)..

This fixes a bug where the software threw an error when no external OSV file could be found. A dedicated function `get_osv_info` was written as the result. This function first searches for external OSV files. If none is found, it reads the name of the OSV file used during L1 processing from the manifest.safe metadata file. Either a file name or None (if no file was found) is then written to the NRB product's metadata.